### PR TITLE
Add a job for GeoAPI 3.1/4.0 draft standard (OGC 23-016).

### DIFF
--- a/.github/workflows/generate_23-016.yml
+++ b/.github/workflows/generate_23-016.yml
@@ -1,0 +1,34 @@
+name: generate_23-016
+on:
+  schedule:
+    - cron:  '1 22 * * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: metanorma/metanorma:latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          path: main
+      - name: Checkout other repo
+        uses: actions/checkout@v3       # checkout the repository content to github runner
+        with:
+          repository: opengeospatial/geoapi
+          path: 23-016
+      - name: Generate document
+        run: |
+          cd 23-016
+          mkdir target                  # Metanorma output will be there.
+
+          # Generate HTML only because the deltas are efficiently handled by versionning systems, contrarily to PDF binary.
+          metanorma compile --output-dir target --agree-to-terms --type ogc --extensions html src/main/metanorma/standard.adoc
+
+          mv ./23-016/target/standard.html ../main/23-016.html
+          cd ../main
+          git config --global user.name 'opengeospatial'
+          git config --global user.email 'opengeospatial@users.noreply.github.com'
+          git add 23-016.html
+          git commit --message "Automated generation of HTML document"
+          git push


### PR DESCRIPTION
The job has been configured for generating only HTML output, because it can be handled efficiently by versionning systems. Git will record only the few lines that have changed, contrarily to binary files such as PDF where the whole file may be written (unless it didn't changed) at each commit.

GeoAPI may be a little bit different than other standards in that the same repository is used for all sources: not only Metanorma, but also Java and Python. This is done that way for ensuring that if we need to update the definition of something, for example `CoordinateSystem`, then a single search will find all occurrences in all kinds of sources, for all languages and including tests and examples. But the issue is that this repository receives a lot of commits that are outside the standard document. It is desirable to not trig a new Metanorma build when the commits where only in Java or Python interfaces. Or if a Metanorma build is nevertheless trigged, the differences should be as small as possible (ideally empty so Git don't create a new commit). Hence the exclusion of PDF output for now.